### PR TITLE
Starts building "static" typechecking dialect.

### DIFF
--- a/evaluator.grace
+++ b/evaluator.grace
@@ -67,7 +67,7 @@ class jevalFamily {
       alias jImplicitRequestNode(_,_,_) at(_) = implicitRequestNode(_,_,_) at(_)
       alias jDefDeclarationNode(_,_,_,_) at(_) = defDeclarationNode(_,_,_,_) at(_)
       alias jVarDeclarationNode(_,_,_,_) at(_) = varDeclarationNode(_,_,_,_) at(_)
-      alias jMethodNode(_,_,_) at(_) = methodNode(_,_,_) at(_)
+      alias jMethodDeclarationNode(_,_,_) at(_) = methodDeclarationNode(_,_,_) at(_)
       alias jBlockNode(_,_) at(_) = blockNode(_,_) at(_)
       alias jReturnNode(_) at(_) = returnNode(_) at (_)
       alias jObjectConstructorNode(_) at(_) = objectConstructorNode(_) at(_)
@@ -175,12 +175,12 @@ class jevalFamily {
           }
   }
 
-  class methodNode(
+  class methodDeclarationNode(
       signature' : Signature,
       body' : Sequence[[Statement]],
       annotations' : Sequence[[Expression]])
           at( source )  -> Method { 
-      inherit jMethodNode(signature', body', annotations') at(source)
+      inherit jMethodDeclarationNode(signature', body', annotations') at(source)
 
       method build(ctxt) { 
           def annots = safeFuckingMap { a -> a.eval(ctxt) } over(annotations)

--- a/kernan-translator.grace
+++ b/kernan-translator.grace
@@ -147,7 +147,7 @@ def visitor = object {  //be careful here. someimes need to refer to visitor
     }
 
     method visitMethod(m) {        
-        jast.methodNode( common(m.signature),
+        jast.methodDeclarationNode( common(m.signature),
                          mapCommon(m.body),
                          mapCommon(m.annotations)) at(0) 
         }

--- a/static.grace
+++ b/static.grace
@@ -1,0 +1,97 @@
+import "platform/KernanCompiler" as kc
+import "combinator-collections" as c
+import "object-model" as om
+import "utility" as utility
+import "kernan-translator" as translator
+import "evaluator" as eval
+import "typechecker" as typechecker
+import "common-ast" as ast
+
+
+inherit c.abbreviations
+use utility.exports
+
+translator.jast := eval.singleton
+
+def objectModel = om.singleton
+
+type ASTNode = interface { } 
+
+def modules = dictionary[[String, ASTNode]]
+
+modules.at(INTRINSICMODULE) put(objectModel.intrinsicModuleObject)
+
+def moduleIsBeingLoaded = object { method isLoaded { false } } 
+
+method loadModule(name : String) { 
+  def mod = modules.at(name) ifAbsent {
+      modules.at(name) put(moduleIsBeingLoaded)
+      def newModuleKernanTree = kc.translateFile(name ++ ".grace")
+      def newModuleCommonTree = translator.translate(newModuleKernanTree)
+      def newModule = newModuleCommonTree.eval(objectModel.context)
+      modules.at(name) put(newModule)
+      return newModule
+  }
+
+  if (!mod.isLoaded) then {error "Module {name} is Loading - circular import" }
+  
+  return mod
+}
+
+
+
+method checker(kernanAst) -> Done {
+    def ast = translator.translate(kernanAst)
+
+
+    print "this is the checker"
+    print "and this is the ast:"
+    print (ast)
+    staticTypesVisitor.visitModule(ast)
+
+}
+
+class staticTypesVisitor {
+    use ast.baseVisitor
+
+    method visitExplicitRequest(node:RequestNode) {
+        print "visiting request of {node.name}"
+        def rcvrType = node.receiver.accept(self)
+        if (rcvrType.isUnknown) then { return typeUnknown }
+        def sig = rcvrType.signatureOf (node.name) ifAbsent {
+            noSuchMethod(node) }
+        checkArguments (node.arguments) against (sig.parameters)
+        return sig.returnType
+    }
+
+    method checkArguments (args) against (types) {
+        for (args) and (types) do { a, t -> checkThat (a) hasType (t) }
+    }
+
+    method checkThat(a) hasType(t) {
+        if (a.accept(self).conformsTo(t).not) then {
+            argument(a)notOfType(t)
+        }
+    }
+
+    method visitNumberLiteral(node : NumberLiteral) -> T {
+        // here we get the type object built from the intrinsic Number type.
+        typechecker.numberType
+    }
+
+    method visitStringLiteral(node : StringLiteral) -> T {
+        typechecker.stringType
+    }
+}
+
+method noSuchMethod(node) {
+    typeError "{node.name} does not exist in {node.receiver}" atNode (node)
+}
+
+method argument(a) notOfType(t) {
+    typeError "{a.asString} does not have type {t}" atNode (a)
+}
+
+method typeError(message) atNode (node) {
+    print "type error! { message } at { node }"
+}

--- a/test/hello.grace
+++ b/test/hello.grace
@@ -1,1 +1,7 @@
-print "Hello World"
+dialect "../static"
+
+self.print "Hello World"
+def x = 6
+method concat(s:String) and (t:String) -> String { s ++ t }
+
+self.print (concat "Hello" and 6)

--- a/typechecker.grace
+++ b/typechecker.grace
@@ -45,7 +45,7 @@ type ObjectType = interface {
     // Used for redispatch in isSubtypeOf(), and does not actually represent a
     // calculation of whether this type is a supertype of the given one.
     // KJX TODO rename to reverseSubtypeOf  - when done copying in tims code
-    isSupertypeOf(other : ObjectType) -> Boolean
+    reverseSubtypeOf(other : ObjectType) -> Boolean
     |(other : ObjectType) -> ObjectType
     &(other : ObjectType) -> ObjectType
 }
@@ -69,14 +69,14 @@ class abstractObjectType {
         block.apply
    }
 
-   method isSupertypeOf(_ : ObjectType) -> Boolean {
+   method reverseSubtypeOf(_ : ObjectType) -> Boolean {
         isStructural && methods.isEmpty
    }
 
    method isSubtypeOf(oType : ObjectType) -> Boolean {
         if (self == oType) then {return true}
         // Let the given type have a say.
-        oType.isSupertypeOf(self).orElse {
+        oType.reverseSubtypeOf(self).orElse {
           oType.isStructural.andAlso {
             isSubtypeOf(oType) withAssumptions(dictionary)
           }
@@ -220,46 +220,65 @@ class objectType( ngInterface ) {
 
 
 class singletonObjectType {
-  inherit abstractObjectType  
-  method equalsOther(other) { other.equalsSingletonObjectType(self) }
-  method equalsSingletonObjectType(other) { asString == other.asString }
+    inherit abstractObjectType
+    method equalsOther(other) { other.equalsSingletonObjectType(self) }
+    method equalsSingletonObjectType(other) { asString == other.asString }
 }
 
 def unknownObjectType is public = object {
-  inherit singletonObjectType
+    inherit singletonObjectType
 
-  def methods = empty
-  method isUnknown { true }  
-  method isStructural { false }
-  method isSubtypeOf(_ : ObjectType) -> Boolean { true }
-  method isSubtypeOf(_ : ObjectType) withAssumptions(_)-> Boolean { true }
-  method isSupertypeOf(_ : ObjectType) -> Boolean { true }
-  method asString { "unknownObjectType" }
+    def methods = empty
+    method isUnknown { true }  
+    method isStructural { false }
+    method isSubtypeOf(_ : ObjectType) -> Boolean { true }
+    method isSubtypeOf(_ : ObjectType) withAssumptions(_)-> Boolean { true }
+    method reverseSubtypeOf(_ : ObjectType) -> Boolean { true }
+    method asString { "type Unknown" }
 }
-
 
 def doneType is public = object { 
-  inherit singletonObjectType
-  
-  def methods = empty
-  method isUnknown { true }  
-  method isStructural { false }
-  method isSubtypeOf(other : ObjectType) -> Boolean { // Let other have a say.
-        other.isSupertypeOf(self).orElse { self == other } }
-  method isSupertypeOf(other : ObjectType) -> Boolean { self == other }
-  method asString { "doneObjectType" }
+    inherit singletonObjectType
+
+    def methods = empty
+    method isUnknown { false }
+    method isStructural { false }
+    method isSubtypeOf(other : ObjectType) -> Boolean {
+        if (self == other) then { return true }
+        other.reverseSubtypeOf(self)
+    }
+    method reverseSubtypeOf(other : ObjectType) -> Boolean { self == other }
+    method asString { "type Done" }
+}
+
+def numberType is public = object {
+    inherit singletonObjectType
+
+    def methods = empty
+    method isUnknown { false }
+    method isStructural { false }
+    method isSubtypeOf(other : ObjectType) -> Boolean {
+        if (self == other) then { return true }
+    }
+    method reverseSubtypeOf(other : ObjectType) -> Boolean { self == other }
+    method asString { "type Number" }
+}
+
+def stringType is public = object {
+    inherit singletonObjectType
+
+    def methods = empty
+    method isUnknown { false }
+    method isStructural { false }
+    method isSubtypeOf(other : ObjectType) -> Boolean {
+        if (self == other) then { return true }
+    }
+    method reverseSubtypeOf(other : ObjectType) -> Boolean { self == other }
+    method asString { "type String" }
 }
 
 
-
-
-
-
-
-
-
-
-class methodType ( signatureNode, ctxt ) { 
+class methodType ( signatureNode, ctxt ) {
    method name { signatureNode.name }
    //def returnObjectType is public = 
    //        makeObjectType(signatureNode.returnType.eval(ctxt.withoutCreatio))


### PR DESCRIPTION
I made some good progress on building a static type checking dialect, but had to 
abandon this branch because there is apparently
no representation of an identifier in the "common-ast" — applied occurences of
identifiers are represented as unresolved "implicitRequests".  Thus, there is
no simple way for a type-cyhecking dialect to, for example, to find out
the declared type of a parameter reference.

Useful to salvage from this branch is the definition of the base AST visitor, from which
specific visitors can inherit.  This means that they need specify visit method only for
the nodes that they wish to examine. 

The "common-ast" is in fact just a representation of the raw syntax, without
any of the analysis that a dialect-writer would need.  Using this ast, the
dialect writer is going to have to reproduce large parts of the compiler — specifically,
the building of the symbol tables, implementing name-visibility due to reuse, and resolving
implicit requests to oneself requests or identifier reference.   An interface for accessing symbol tables
should also be provided.

To fix this, its is necessary to add identifier references to the AST; also sequences (unless we
represent sequences as requests of a reserved name).  Reuse statements should be differentiated (inherit vs use)
and dialect statements should probably be represented similarly to import statements as two 
subclasses of "external". 

Regarding the unresolved "implicit requests", It might be possible to have a method `resolve` 
on each unresolved request that would invoke the compiler logic to resolve it, and return a oneself
request, or identifier reference.  Although why this would be preferable to having
done the work eagerly escapes me.  Simplicity of implementation vs simplicity of interface?

Going forward, it makes more sense to abandon this fork and move the type-
checker to minigrace.